### PR TITLE
Home banner scaling fix.

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,11 +61,7 @@
   </div>
 
   <!-- home image -->
-  <div class="home" style="background-image:url('https://www.blindcatrescue.com/index_htm_files/315605.jpg');
-    background-size: cover;
-    height: 120vh; width: 100vw
-    overflow: hidden;">
-  </div>
+  <img src="https://www.blindcatrescue.com/index_htm_files/315605.jpg" style='width: 100%;'>
 
   <!--  -->
   <section class="TextBox">


### PR DESCRIPTION
Only the left half of the banner was shown on mobile/screens with nonstandard aspect ratios. Fixed by making it an actual image and basing it on width, not height.